### PR TITLE
Grafana Docker Update & Dynamic Datasource URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a set of packages to configure [Grafana](https://grafana.com/) and install dashboards, data sources and other resources used by perfSONAR. 
 
 # Editing Dashboards
-This repository provides a Docker setup that runs Grafana and installs the dashboards in an editable mode. The datasources can be updated to point at a development archive so you also have data with which to work. You can do this by editing the Dockerfile to update the datasource with the URL of your archive (see comments in Dockerfile). To use the development environment perform the following steps:
+This repository provides a Docker setup that runs Grafana and installs the dashboards in an editable mode. The datasources can be updated to point at a development archive so you also have data with which to work. You can do this by setting the `PERFSONAR_OPENSEARCH_URL` environment variable in the `docker-compose.yml` file provided. To use the development environment perform the following steps:
 
 1. Run the following to start the container:
 ```

--- a/perfsonar-grafana/perfsonar-grafana/Dockerfile
+++ b/perfsonar-grafana/perfsonar-grafana/Dockerfile
@@ -1,14 +1,32 @@
-FROM grafana/grafana:10.4.7-ubuntu
+FROM grafana/grafana:11.6.3-ubuntu
 
-COPY . /usr/lib/perfsonar/grafana
+ARG PERFSONAR_ROOTPATH_ARG=/usr/lib/perfsonar/grafana
+ENV PERFSONAR_ROOTPATH=${PERFSONAR_ROOTPATH_ARG}
 
 USER root
-#Setup provisioning
-RUN mkdir -p /usr/lib/perfsonar/grafana/dashboards/empty
-RUN  cp -r /usr/lib/perfsonar/grafana/images/* /usr/share/grafana/public/img/
-RUN sed -i /usr/lib/perfsonar/grafana/provisioning/dashboards/*.yaml -e 's/allowUiUpdates: false/allowUiUpdates: true/g'
+
+#Create nessessary directories for Grafana provisioning
+RUN mkdir -p ${PERFSONAR_ROOTPATH}
+RUN mkdir -p ${PERFSONAR_ROOTPATH}/provisioning/access-control
+RUN mkdir -p ${PERFSONAR_ROOTPATH}/provisioning/alerting
+RUN mkdir -p ${PERFSONAR_ROOTPATH}/provisioning/notifiers
+RUN mkdir -p ${PERFSONAR_ROOTPATH}/provisioning/plugins
+RUN mkdir -p ${PERFSONAR_ROOTPATH}/dashboards/empty
+
+#Copy perfSONAR Grafana files
+COPY images/ /usr/share/grafana/public/img/
+COPY provisioning/dashboards/ ${PERFSONAR_ROOTPATH}/provisioning/dashboards/
+COPY provisioning/datasources/ ${PERFSONAR_ROOTPATH}/provisioning/datasources/
+COPY dashboards/ ${PERFSONAR_ROOTPATH}/dashboards/
+
+RUN chown -R grafana:root ${PERFSONAR_ROOTPATH}
+
+#Make the provisioned dashboards and datasources editable through the user interface
+RUN sed -i ${PERFSONAR_ROOTPATH}/provisioning/dashboards/*.yaml -e 's/allowUiUpdates: false/allowUiUpdates: true/g'
+RUN sed -i ${PERFSONAR_ROOTPATH}/provisioning/datasources/*.yaml -e 's/editable: false/editable: true/g'
+
 #Uncomment below to point datasource at different MA by default
-RUN sed -i /usr/lib/perfsonar/grafana/provisioning/datasources/*.yaml -e 's/localhost/34.72.54.168/g'
+#RUN sed -i /usr/lib/perfsonar/grafana/provisioning/datasources/*.yaml -e 's/localhost/34.72.54.168/g'
 
 USER grafana
 EXPOSE 3000

--- a/perfsonar-grafana/perfsonar-grafana/Dockerfile
+++ b/perfsonar-grafana/perfsonar-grafana/Dockerfile
@@ -25,8 +25,12 @@ RUN chown -R grafana:root ${PERFSONAR_ROOTPATH}
 RUN sed -i ${PERFSONAR_ROOTPATH}/provisioning/dashboards/*.yaml -e 's/allowUiUpdates: false/allowUiUpdates: true/g'
 RUN sed -i ${PERFSONAR_ROOTPATH}/provisioning/datasources/*.yaml -e 's/editable: false/editable: true/g'
 
-#Uncomment below to point datasource at different MA by default
-#RUN sed -i /usr/lib/perfsonar/grafana/provisioning/datasources/*.yaml -e 's/localhost/34.72.54.168/g'
+# This script will run before Grafana starts to modify the datasource URLs.
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# The original Grafana CMD (which starts Grafana) will now be passed as arguments to our entrypoint script.
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 USER grafana
 EXPOSE 3000

--- a/perfsonar-grafana/perfsonar-grafana/docker-compose.yml
+++ b/perfsonar-grafana/perfsonar-grafana/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   grafana:
     restart: &grafana-restart always
@@ -13,6 +12,12 @@ services:
       - GF_PATHS_PROVISIONING=/usr/lib/perfsonar/grafana/provisioning
       - GF_SERVER_ROOT_URL=%(protocol)s://%(domain)s:%(http_port)s/grafana/
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      - PERFSONAR_OPENSEARCH_URL=http://opensearch-node:9200
     ports:
       &grafana-ports
        - 3000:3000
+    volumes:
+      - grafana-data:/var/lib/grafana
+
+volumes:
+  grafana-data:

--- a/perfsonar-grafana/perfsonar-grafana/docker-entrypoint.sh
+++ b/perfsonar-grafana/perfsonar-grafana/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+DATASOURCE_YAML_FILES=(
+    "/usr/lib/perfsonar/grafana/provisioning/datasources/perfsonar-local.yaml"
+    "/usr/lib/perfsonar/grafana/provisioning/datasources/exporter-metrics-local.yaml"
+)
+
+# Check if the PERFSONAR_OPENSEARCH_URL environment variable is set.
+if [ -n "${PERFSONAR_OPENSEARCH_URL}" ]; then
+    for DATASOURCE_FILE in "${DATASOURCE_YAML_FILES[@]}"; do
+        echo "Setting OpenSearch URL to: ${PERFSONAR_OPENSEARCH_URL} in ${DATASOURCE_FILE}"
+        # Use '|' as a delimiter for sed to avoid issues with '/' in URLs.
+        sed -i "s|https://localhost/opensearch|${PERFSONAR_OPENSEARCH_URL}|g" "${DATASOURCE_FILE}"
+    done
+fi
+
+# Execute the original Grafana entrypoint script (/run.sh) with all passed arguments.
+# This ensures that Grafana's own startup logic, as defined by its base image, is followed.
+exec /run.sh "$@"


### PR DESCRIPTION
This PR updates the Grafana Docker setup with the following key changes:

- **Grafana Image Upgrade**: Switched base image to `grafana/grafana:11.6.3-ubuntu`.

- **Dynamic Datasource URL**: Implemented `PERFSONAR_OPENSEARCH_URL` environment variable for configuring OpenSearch datasource URLs in `perfsonar-local.yaml` and `exporter-metrics-local.yaml` via `docker-compose.yml`.

- **Custom Entrypoint**: Added `docker-entrypoint.sh` to handle runtime URL substitution and ensure proper Grafana startup (`/run.sh`).

- **Datasources Editable**: Configured provisioned datasources to be editable directly through the Grafana web UI.