### PR TITLE
Sets max and min for CPU utilization graph in Host Metrics dashboard

### DIFF
--- a/perfsonar-grafana/perfsonar-grafana/dashboards/toolkit/perfsonar-host-metrics.json
+++ b/perfsonar-grafana/perfsonar-grafana/dashboards/toolkit/perfsonar-host-metrics.json
@@ -1483,6 +1483,8 @@
             }
           },
           "mappings": [],
+          "max": 1,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [


### PR DESCRIPTION
Sets max and min boundaries to limit the display of erroneous CPU utilization values.